### PR TITLE
Header should work also on non-Arduino ENVs

### DIFF
--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -10,10 +10,12 @@
 #ifndef __RF24_CONFIG_H__
 #define __RF24_CONFIG_H__
 
-#if ARDUINO < 100
-#include <WProgram.h>
-#else
-#include <Arduino.h>
+#if defined (ARDUINO)
+  #if ARDUINO < 100
+    #include <WProgram.h>
+  #else
+    #include <Arduino.h>
+  #endif
 #endif
 
 #include <stddef.h>


### PR DESCRIPTION
Simple check if the arduino variable/macro is present, do nothing
otherwise.