### PR TITLE
Add compatibility for Arduino ESP8266 architecture

### DIFF
--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -84,7 +84,12 @@
 
 // Progmem is Arduino-specific
 // Arduino DUE is arm and does not include avr/pgmspace
-#if defined(ARDUINO) && ! defined(__arm__)  && !defined (__ARDUINO_X86__)
+#if defined (ARDUINO_ARCH_ESP8266)
+	#include <pgmspace.h>
+	#define PRIPSTR "%S"
+	#define printf_P printf
+	#define sprintf_P sprintf
+#elif defined(ARDUINO) && ! defined(__arm__)  && !defined (__ARDUINO_X86__)
 	#include <avr/pgmspace.h>
 	#define PRIPSTR "%S"
 #else


### PR DESCRIPTION
Similar to the https://github.com/TMRh20/RF24/commit/cd52d61bc08c3c3e46b5164a056b29e61fdf2689#diff-850bb3124375ff25ac4198addd330b6e commit in the RF24 repo, some changes needed to be made to `RF24Network_config.h` for the RF24Network library to compile and run on the ESP8266.

p.s. Let me know if you would like this pull request against the Development branch instead of master