### PR TITLE
Examples should be excluded from platformio library.json file

### DIFF
--- a/library.json
+++ b/library.json
@@ -8,9 +8,11 @@
     "url": "https://github.com/TMRh20/RF24Network.git"
   },
   "dependencies": { "name": "RF24", "authors": "TMRh20", "frameworks": "arduino" },
-  "exclude": [ 
-    "RPi",
-    "tests"
+  "exclude": [
+    "examples/*",
+    "examples_RPi/*",
+    "RPi/*",
+    "tests/*"
   ],
   "frameworks": "arduino",
   "platforms": [


### PR DESCRIPTION
If examples are not excluded, platformio will try to build them (and fail).

This change has been lightly tested by modifying the library.json file locally. I'm not really sure how I could do more integration testing with platformio (if you know, I'll be happy  to do it !).

This PR *should* fix #57.