### PR TITLE
Update pyRF24Network.cpp

### DIFF
--- a/RPi/pyRF24Network/pyRF24Network.cpp
+++ b/RPi/pyRF24Network/pyRF24Network.cpp
@@ -44,8 +44,8 @@ bp::tuple read_wrap(RF24Network& ref, size_t maxlen)
 	char *buf = new char[maxlen+1];
 	RF24NetworkHeader header;
 
-	ref.read(header, buf, maxlen);
-    bp::object py_ba(bp::handle<>(PyByteArray_FromStringAndSize(buf, maxlen)));
+	uint16_t len = ref.read(header, buf, maxlen);
+    bp::object py_ba(bp::handle<>(PyByteArray_FromStringAndSize(buf, len)));
     delete[] buf;
 	
 	return bp::make_tuple(header, py_ba);


### PR DESCRIPTION
Fix length of buffer returned from read(). Currently always returns the 'maxlen' the user passed in, rather than the actual number of bytes read from the network.