### PR TITLE
Possibility to setup the interrupt_mode in sleepnode

### DIFF
--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -1294,7 +1294,7 @@ ISR(WDT_vect){
 }
 
 
-bool RF24Network::sleepNode( unsigned int cycles, int interruptPin, int INTERRUPT_MODE){
+bool RF24Network::sleepNode( unsigned int cycles, int interruptPin, uint8_t INTERRUPT_MODE){
 
 
   sleep_cycles_remaining = cycles;
@@ -1302,10 +1302,12 @@ bool RF24Network::sleepNode( unsigned int cycles, int interruptPin, int INTERRUP
   sleep_enable();
   if(interruptPin != 255){
     wasInterrupted = false; //Reset Flag
-  	if(INTERRUPT_MODE==0) attachInterrupt(interruptPin,wakeUp, LOW);
-	if(INTERRUPT_MODE==1) attachInterrupt(interruptPin,wakeUp, RISING);
-	if(INTERRUPT_MODE==2) attachInterrupt(interruptPin,wakeUp, FALLING);
-	if(INTERRUPT_MODE==3) attachInterrupt(interruptPin,wakeUp, CHANGE);
+	//LOW,CHANGE, FALLING, RISING correspond with the values 0,1,2,3 respectively
+	attachInterrupt(interruptPin,wakeUp, INTERRUPT_MODE);
+  	//if(INTERRUPT_MODE==0) attachInterrupt(interruptPin,wakeUp, LOW);
+	//if(INTERRUPT_MODE==1) attachInterrupt(interruptPin,wakeUp, RISING);
+	//if(INTERRUPT_MODE==2) attachInterrupt(interruptPin,wakeUp, FALLING);
+	//if(INTERRUPT_MODE==3) attachInterrupt(interruptPin,wakeUp, CHANGE);
   }    
 
   #if defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -1294,7 +1294,7 @@ ISR(WDT_vect){
 }
 
 
-bool RF24Network::sleepNode( unsigned int cycles, int interruptPin ){
+bool RF24Network::sleepNode( unsigned int cycles, int interruptPin, int INTERRUPT_MODE){
 
 
   sleep_cycles_remaining = cycles;
@@ -1302,7 +1302,10 @@ bool RF24Network::sleepNode( unsigned int cycles, int interruptPin ){
   sleep_enable();
   if(interruptPin != 255){
     wasInterrupted = false; //Reset Flag
-  	attachInterrupt(interruptPin,wakeUp, LOW);
+  	if(INTERRUPT_MODE==0) attachInterrupt(interruptPin,wakeUp, LOW);
+	if(INTERRUPT_MODE==1) attachInterrupt(interruptPin,wakeUp, RISING);
+	if(INTERRUPT_MODE==2) attachInterrupt(interruptPin,wakeUp, FALLING);
+	if(INTERRUPT_MODE==3) attachInterrupt(interruptPin,wakeUp, CHANGE);
   }    
 
   #if defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -622,7 +622,7 @@ public:
    * @param interruptPin: The interrupt number to use (0,1) for pins two and three on Uno,Nano. More available on Mega etc.
    * @return True if sleepNode completed normally, after the specified number of cycles. False if sleep was interrupted
    */
- bool sleepNode( unsigned int cycles, int interruptPin );
+ bool sleepNode( unsigned int cycles, int interruptPin, int INTERRUPT_MODE=0); //added interrupt mode support (default 0=LOW)
 
 
   /**

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -622,7 +622,7 @@ public:
    * @param interruptPin: The interrupt number to use (0,1) for pins two and three on Uno,Nano. More available on Mega etc.
    * @return True if sleepNode completed normally, after the specified number of cycles. False if sleep was interrupted
    */
- bool sleepNode( unsigned int cycles, int interruptPin, int INTERRUPT_MODE=0); //added interrupt mode support (default 0=LOW)
+ bool sleepNode( unsigned int cycles, int interruptPin, uint8_t INTERRUPT_MODE=0); //added interrupt mode support (default 0=LOW)
 
 
   /**


### PR DESCRIPTION
Now it is possible to setup the interrupt mode in sleepnode (default 0=LOW, i.e. it is mantained the compatibility with older versions if nothing is declared)

if(INTERRUPT_MODE==0) attachInterrupt(interruptPin,wakeUp, LOW)
if(INTERRUPT_MODE==1) attachInterrupt(interruptPin,wakeUp, RISING)
if(INTERRUPT_MODE==2) attachInterrupt(interruptPin,wakeUp, FALLING)
if(INTERRUPT_MODE==3) attachInterrupt(interruptPin,wakeUp, CHANGE)

This is useful, for instance, with PIR sensors that require settings different from LOW
